### PR TITLE
Push to the PR branch instead of main in pr-pull

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,10 +26,4 @@ jobs:
         uses: Homebrew/actions/git-try-push@master
         with:
           token: ${{ github.token }}
-          branch: main
-
-      - name: Delete branch
-        if: github.event.pull_request.head.repo.fork == false
-        env:
-          BRANCH: ${{ github.event.pull_request.head.ref }}
-        run: git push --delete origin $BRANCH
+          branch: ${{ github.head_ref }}


### PR DESCRIPTION
The default homebrew workflow has PRs being merged directly by `publish.yml` when the `pr-pull` label is added. This is incompatible with our typical branch protection rules. As an alternative, this patch pushes the changes directly to the PR branch to be merged manually by a developer.