### PR TITLE
Build Linux bottles on Ubuntu 20.04

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-20.04
           - macos-latest
           - [self-hosted, macos, arm64]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
To ensure support for older OSes, this patch builds our Linux bottles on Ubuntu 20.04 instead of Ubuntu latest (currently 22.04).