### PR TITLE
Add phylum completion files

### DIFF
--- a/Formula/phylum.rb
+++ b/Formula/phylum.rb
@@ -7,6 +7,13 @@ class Phylum < Formula
   revision 1
   head "https://github.com/phylum-dev/cli.git", branch: "main"
 
+  bottle do
+    root_url "https://github.com/phylum-dev/homebrew-cli/releases/download/phylum-4.0.0_1"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "8754ae58126931e50deb0271e567fa8047e71f45a1043ec479146cc1d23dbd75"
+    sha256 cellar: :any_skip_relocation, monterey:       "be3ab2f1edd73028c601aea86619e4860d69d85355cbdbf44502dd80c10de289"
+    sha256                               x86_64_linux:   "5b669ce7d483185f46df4787ba64e816ccdbf0a99fa00b2efdbfa031d5dfd047"
+  end
+
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
This patch adds shell completion files to the `phylum` formula.

After installing this new revision, the completion files will be included in the cellar and symlinks will be available at the following locations:

* `$(brew --prefix)/share/zsh/site-functions/_phylum`
* `$(brew --prefix)/etc/bash_completion.d/phylum.bash`
* `$(brew --prefix)/share/fish/vendor_completions.d/phylum.fish`

Additional details on shell completion in Homebrew can be found in [their docs](https://docs.brew.sh/Shell-Completion)