### PR TITLE
phylum 4.5.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,12 @@ on:
     paths:
       - Formula/*.rb
 
+env:
+  # This environment variable is not documented, but is needed to
+  # prevent failures and destructive actions added in this commit:
+  # https://github.com/Homebrew/actions/commit/616a563beaa0715ddebbb39a331224af1b46fdaa
+  GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED: 1
+
 jobs:
   build-bottles:
     strategy:

--- a/Formula/phylum.rb
+++ b/Formula/phylum.rb
@@ -1,8 +1,8 @@
 class Phylum < Formula
   desc "Software Supply Chain Security CLI"
   homepage "https://phylum.io"
-  url "https://github.com/phylum-dev/cli/archive/refs/tags/v4.4.0.tar.gz"
-  sha256 "6755134852518c6abd4d3a779c72c1698e308bcf79334d4f404b56750af68fd3"
+  url "https://github.com/phylum-dev/cli/archive/refs/tags/v4.5.0.tar.gz"
+  sha256 "1145b22b1f8fa42ce81c8b67d7e5122577432a600f1fbb091c02a8619e7ad90c"
   license "GPL-3.0-or-later"
   head "https://github.com/phylum-dev/cli.git", branch: "main"
 


### PR DESCRIPTION
This PR is like #19 in that it is also for the Phylum CLI v4.5.0 release. However, it does not contain the workflow updates to pin the `setup-homebrew` action to a previous version. Only one of these PRs should be allowed to proceed to the "publish bottles" step...which requires a manual approval. If this PR works, it should be this one. Otherwise, proceed with #19