### PR TITLE
ci: checkout repo before setting up brew

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -34,13 +34,15 @@ jobs:
     name: Bump Formula and create PR
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+
       - name: Set up Homebrew
         # NOTE: A specific commit is used here because this action does not
         #       publish tags and the current `master` appears to be broken.
         uses: Homebrew/actions/setup-homebrew@449449e64aaa5faac0d24229a2ffba32438e4b63
-
-      - name: Checkout the repository
-        uses: actions/checkout@v3
+        with:
+          debug: true
 
       - name: Set up git
         uses: Homebrew/actions/git-user-config@master


### PR DESCRIPTION
With the `homebrew-cli` repo updated now to include a first draft of the "bump" workflow, I'm starting to iterate on it...triggering the workflow locally for the CLI v4.7.0 release. The [first attempt failed](https://github.com/phylum-dev/homebrew-cli/actions/runs/4287457567/jobs/7468336703) but it is not exactly clear how/why it failed...at least from reading the logs there. This PR takes the assumption that maybe the `actions/checkout` action needs to occur before the `Homebrew/actions/setup-homebrew` action. It also enables the debug output for that latter action.