### PR TITLE
ci: go back to using setup-homebrew action from master

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -38,9 +38,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Homebrew
-        # NOTE: A specific commit is used here because this action does not
-        #       publish tags and the current `master` appears to be broken.
-        uses: Homebrew/actions/setup-homebrew@449449e64aaa5faac0d24229a2ffba32438e4b63
+        uses: Homebrew/actions/setup-homebrew@master
         with:
           debug: true
 


### PR DESCRIPTION
I think recent [changes to the `setup-homebrew` action](https://github.com/Homebrew/actions/pull/332) will fix the errors that have been seen on the recent workflow runs. This PR removes the SHA pin and goes back to tracking the action from `master` (they do not publish any tags to follow). This change will not affect/destroy any self-hosted runners b/c the entire workflow only makes use of GitHub hosted runners.