### PR TITLE
ci: skip the brew audit when bumping the formula

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -51,4 +51,4 @@ jobs:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           CLI_VER_WITHOUT_v=$(echo ${{ github.event.client_payload.CLI_version }} | sed 's/v//')
-          brew bump-formula-pr --version $CLI_VER_WITHOUT_v --no-fork --no-browse --debug --verbose phylum
+          brew bump-formula-pr --version $CLI_VER_WITHOUT_v --no-fork --no-browse --no-audit --debug --verbose phylum


### PR DESCRIPTION
Switching the `setup-homebrew` action back to `master` is working now to get past the previous error. Now it is failing due to a failed `brew audit` that checks the formula syntax. It is failing because it sees that the formula depends on `rust` but Rust was not installed on the runner in CI. So...we could either install/setup Rust on the runner or use the `--no-audit` flag to skip that step.

This PR goes with the `--no-audit` path because the Formula is not changing in any relevant way other than to update the `url` and `sha256` values to correspond with the CLI release that triggered the workflow.