### PR TITLE
ci: try setting the remote to the SSH form

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -50,5 +50,6 @@ jobs:
           HOMEBREW_DEVELOPER: "1"
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          git remote set-url origin git@github.com:"$GITHUB_REPOSITORY".git
           CLI_VER_WITHOUT_v=$(echo ${{ github.event.client_payload.CLI_version }} | sed 's/v//')
           brew bump-formula-pr --version $CLI_VER_WITHOUT_v --no-fork --no-browse --no-audit --debug --verbose phylum

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -52,4 +52,5 @@ jobs:
         run: |
           git remote set-url origin git@github.com:"$GITHUB_REPOSITORY".git
           CLI_VER_WITHOUT_v=$(echo ${{ github.event.client_payload.CLI_version }} | sed 's/v//')
-          brew bump-formula-pr --version $CLI_VER_WITHOUT_v --no-fork --no-browse --no-audit --debug --verbose phylum
+          printf "CLI_VER_WITHOUT_v: %s" "$CLI_VER_WITHOUT_v"
+          brew bump-formula-pr --version "$CLI_VER_WITHOUT_v" --no-fork --no-browse --no-audit --debug --verbose phylum

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,7 @@ jobs:
           name: bottles
 
       - name: Merge bottles
-        run: brew bottle --merge --write --debug *.bottle.json
+        run: brew bottle --merge --write --debug ./*.bottle.json
 
       - name: Push commits
         run: git push


### PR DESCRIPTION
The [errors seen in the bump workflow](https://github.com/phylum-dev/homebrew-cli/actions/runs/4295739319/jobs/7486561937) are now related to pushing. [This blog post](https://nikola-breznjak.com/blog/quick-tips/git-push-origin-master-could-not-read-username-for-httpgithub-com/) describes the error and provided a simple solution that makes sense. This PR attempts that solution. It also added some additional output and fixed some `actionlint`/`shellcheck` findings.