### PR TITLE
ci: dump `homebrew` actions in favor of manual formula bumping

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -49,16 +49,14 @@ jobs:
           git_commit_gpgsign: true
 
       - name: Update URL and SHA256 values
-        id: commit
-        continue-on-error: true
         # NOTE: The `archive/refs/tags` link is used instead of the `tarball_url` provided by the release API because
         #       the hashes between the two are (currently) different, even though the extracted contents are the same.
         #       The `archive/refs/tags` link format is used by the formula and is therefore the one downloaded here.
         #       Reference: https://github.com/community/community/discussions/45830
         # NOTE: The git user name/email used for commits is already configured, by crazy-max/ghaction-import-gpg action.
         run: |
-          curl -sSfLo "cli-${CLI_VER#v}.tar.gz" "https://github.com/phylum-dev/cli/archive/refs/tags/${CLI_VER}.tar.gz"
-          TARBALL_SHA=$(sha256sum "cli-${CLI_VER#v}.tar.gz" | cut -d' ' -f1)
+          curl -sSfLO "https://github.com/phylum-dev/cli/archive/refs/tags/${CLI_VER}.tar.gz"
+          TARBALL_SHA=$(sha256sum "${CLI_VER}.tar.gz" | cut -d' ' -f1)
           sed -E -i '' "/^  url /s/\/v.*.tar.gz/\/${CLI_VER}.tar.gz/" Formula/phylum.rb
           sed -E -i '' "/^  sha256 /s/.*/  sha256 \"${TARBALL_SHA}\"/" Formula/phylum.rb
           git add Formula/phylum.rb
@@ -66,7 +64,6 @@ jobs:
           git push --force origin "HEAD:bump-phylum-${CLI_VER#v}"
 
       - name: Create Pull Request
-        if: ${{ steps.commit.outcome == 'success' }}
         uses: actions/github-script@v6
         with:
           # This PAT is for the `phylum-bot` account and only has the `public_repo` scope to limit privileges.
@@ -78,6 +75,12 @@ jobs:
               head: "bump-phylum-${CLI_VER#v}",
               base: context.ref,
               title: "phylum ${CLI_VER#v}",
-              body: "Wait for a new commit to be automatically added by first set of jobs _before_ approving this PR.",
+              body: "Reminder: It is better to wait for the first 4 jobs "
+                  + "(3 for `build-bottles` and 1 for `brew-bottle`) to "
+                  + "complete before approving this PR because the PR will "
+                  + "be updated by that 4th job with a new commit that updates "
+                  + "the formula to include the new bottle `root_url` and `sha256` "
+                  + "values. Additionally, this PR should not be merged to `main` "
+                  + "until _after_ the bottles have been successfully published.",
             });
             console.log(response);

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -33,12 +33,11 @@ jobs:
   bump:
     name: Bump Formula and create PR
     runs-on: ubuntu-latest
+    env:
+      CLI_VER: ${{ github.event.client_payload.CLI_version }}
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
-        with:
-          # This PAT is for the `phylum-bot` account and only has the `public_repo` scope to limit privileges.
-          token: ${{ secrets.GH_RELEASE_PAT }}
 
       # This GPG key is for the `phylum-bot` account and used in order to ensure commits are signed/verified
       - name: Import GPG key for bot account
@@ -48,21 +47,37 @@ jobs:
           passphrase: ${{ secrets.PHYLUM_BOT_GPG_PASSPHRASE }}
           git_user_signingkey: true
           git_commit_gpgsign: true
-          git_config_global: true
 
-      - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
-        with:
-          debug: true
-          # This PAT is for the `phylum-bot` account and only has the `public_repo` scope to limit privileges.
-          token: ${{ secrets.GH_RELEASE_PAT }}
-
-      - name: Create a PR with new formula URL and SHA
-        env:
-          HOMEBREW_DEVELOPER: "1"
-          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
+      - name: Update URL and SHA256 values
+        id: commit
+        continue-on-error: true
+        # NOTE: The `archive/refs/tags` link is used instead of the `tarball_url` provided by the release API because
+        #       the hashes between the two are (currently) different, even though the extracted contents are the same.
+        #       The `archive/refs/tags` link format is used by the formula and is therefore the one downloaded here.
+        #       Reference: https://github.com/community/community/discussions/45830
+        # NOTE: The git user name/email used for commits is already configured, by crazy-max/ghaction-import-gpg action.
         run: |
-          git remote set-url origin git@github.com:"$GITHUB_REPOSITORY".git
-          CLI_VER_WITHOUT_v=$(echo ${{ github.event.client_payload.CLI_version }} | sed 's/v//')
-          printf "CLI_VER_WITHOUT_v: %s\n" "$CLI_VER_WITHOUT_v"
-          brew bump-formula-pr --version "$CLI_VER_WITHOUT_v" --no-fork --no-browse --no-audit --debug --verbose phylum
+          curl -sSfLo "cli-${CLI_VER#v}.tar.gz" "https://github.com/phylum-dev/cli/archive/refs/tags/${CLI_VER}.tar.gz"
+          TARBALL_SHA=$(sha256sum "cli-${CLI_VER#v}.tar.gz" | cut -d' ' -f1)
+          sed -E -i'.bak' "/^  url /s/\/v.*.tar.gz/\/${CLI_VER}.tar.gz/" Formula/phylum.rb
+          sed -E -i'.bak' "/^  sha256 /s/.*/  sha256 \"${TARBALL_SHA}\"/" Formula/phylum.rb
+          git add Formula/phylum.rb
+          git commit -m "phylum ${CLI_VER#v}"
+          git push --force origin "HEAD:bump-phylum-${CLI_VER#v}"
+
+      - name: Create Pull Request
+        if: ${{ steps.commit.outcome == 'success' }}
+        uses: actions/github-script@v6
+        with:
+          # This PAT is for the `phylum-bot` account and only has the `public_repo` scope to limit privileges.
+          github-token: ${{ secrets.GH_RELEASE_PAT }}
+          script: |
+            const response = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: "bump-phylum-${CLI_VER#v}",
+              base: context.ref,
+              title: "phylum ${CLI_VER#v}",
+              body: "Wait for a new commit to be automatically added by first set of jobs _before_ approving this PR.",
+            });
+            console.log(response);

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -59,8 +59,8 @@ jobs:
         run: |
           curl -sSfLo "cli-${CLI_VER#v}.tar.gz" "https://github.com/phylum-dev/cli/archive/refs/tags/${CLI_VER}.tar.gz"
           TARBALL_SHA=$(sha256sum "cli-${CLI_VER#v}.tar.gz" | cut -d' ' -f1)
-          sed -E -i'.bak' "/^  url /s/\/v.*.tar.gz/\/${CLI_VER}.tar.gz/" Formula/phylum.rb
-          sed -E -i'.bak' "/^  sha256 /s/.*/  sha256 \"${TARBALL_SHA}\"/" Formula/phylum.rb
+          sed -E -i '' "/^  url /s/\/v.*.tar.gz/\/${CLI_VER}.tar.gz/" Formula/phylum.rb
+          sed -E -i '' "/^  sha256 /s/.*/  sha256 \"${TARBALL_SHA}\"/" Formula/phylum.rb
           git add Formula/phylum.rb
           git commit -m "phylum ${CLI_VER#v}"
           git push --force origin "HEAD:bump-phylum-${CLI_VER#v}"


### PR DESCRIPTION
The `Homebrew/actions/*` actions do not appear to be flexible enough to work in the manner intended for this repository. They make certain assumptions that do not hold. Specifically, the `brew bump-formula-pr` command attempts to `git push` in a way that does not work with the `phylum-bot` user token and signing restrictions in place. [Several attempts were made](https://github.com/phylum-dev/homebrew-cli/actions/workflows/bump.yml) to work around these limitations, but the time taken to figure that out was dragging on and a decision was made to just re-write the workflow to manually swap out the `phylum` formula values for `url` and `sha256`, commit the changes, push them, and start a PR. The changes made here adhere to `actionlint` and `shellcheck` and are believed to work as intended...but it won't be truly possible to tell until the workflow is triggered after it gets merged to the `main` branch.