### PR TITLE
ci: change sed to work on both macOS and linux

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -57,8 +57,8 @@ jobs:
         run: |
           curl -sSfLO "https://github.com/phylum-dev/cli/archive/refs/tags/${CLI_VER}.tar.gz"
           TARBALL_SHA=$(sha256sum "${CLI_VER}.tar.gz" | cut -d' ' -f1)
-          sed -E -i '' "/^  url /s/\/v.*.tar.gz/\/${CLI_VER}.tar.gz/" Formula/phylum.rb
-          sed -E -i '' "/^  sha256 /s/.*/  sha256 \"${TARBALL_SHA}\"/" Formula/phylum.rb
+          sed -E -i'.bak' "/^  url /s/\/v.*.tar.gz/\/${CLI_VER}.tar.gz/" Formula/phylum.rb
+          sed -E -i'.bak' "/^  sha256 /s/.*/  sha256 \"${TARBALL_SHA}\"/" Formula/phylum.rb
           git add Formula/phylum.rb
           git commit -m "phylum ${CLI_VER#v}"
           git push --force origin "HEAD:bump-phylum-${CLI_VER#v}"


### PR DESCRIPTION
The `sed` command(s) as written did not work:
https://github.com/phylum-dev/homebrew-cli/actions/runs/4358238767/jobs/7618552842
```
Run curl -sSfLO "https://github.com/phylum-dev/cli/archive/refs/tags/${CLI_VER}.tar.gz"
  curl -sSfLO "https://github.com/phylum-dev/cli/archive/refs/tags/${CLI_VER}.tar.gz"
  TARBALL_SHA=$(sha256sum "${CLI_VER}.tar.gz" | cut -d' ' -f1)
  sed -E -i '' "/^  url /s/\/v.*.tar.gz/\/${CLI_VER}.tar.gz/" Formula/phylum.rb
  sed -E -i '' "/^  sha256 /s/.*/  sha256 \"${TARBALL_SHA}\"/" Formula/phylum.rb
  git add Formula/phylum.rb
  git commit -m "phylum ${CLI_VER#v}"
  git push --force origin "HEAD:bump-phylum-${CLI_VER#v}"
  shell: /usr/bin/bash -e {0}
  env:
    CLI_VER: v4.7.0
  
sed: can't read /^  url /s/\/v.*.tar.gz/\/v4.7.0.tar.gz/: No such file or directory
Error: Process completed with exit code 2.
```

The proposed change is the same format as used in the `cli` repo for `ubuntu-latest` systems. It does create a backup file, but the `git add` command is specific about the files it adds...so it shouldn't cause any trouble. Plus, it lines up with the suggested solution from [this SO post](https://stackoverflow.com/questions/4247068/sed-command-with-i-option-failing-on-mac-but-works-on-linux).