### PR TITLE
fix: the `publish` workflow fails on `ubuntu-20.04` runner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,16 +11,16 @@ jobs:
         os:
           - ubuntu-20.04
           - macos-latest
-        include:
-          - os: [self-hosted, macos, arm64]
-            env:
-              # This environment variable is not documented, but is needed to
-              # prevent failures and destructive actions added in this commit:
-              # https://github.com/Homebrew/actions/commit/616a563beaa0715ddebbb39a331224af1b46fdaa
-              GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED: '1'
+          - [self-hosted, macos, arm64]
     runs-on: ${{ matrix.os }}
-    env: ${{ matrix.env }}
     steps:
+      - name: Set environment
+        if: contains(${{ matrix.os }}, 'self-hosted')
+        # This environment variable is not documented, but is needed to
+        # prevent failures and destructive actions added in this commit:
+        # https://github.com/Homebrew/actions/commit/616a563beaa0715ddebbb39a331224af1b46fdaa
+        run: echo "GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED=1" >> $GITHUB_ENV
+
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,22 +11,17 @@ jobs:
         os:
           - ubuntu-20.04
           - macos-latest
-          - [self-hosted, macos, arm64]
+        include:
+          - os: [self-hosted, macos, arm64]
+            env:
+              # This environment variable is not documented, but is needed to
+              # prevent failures and destructive actions added in this commit:
+              # https://github.com/Homebrew/actions/commit/616a563beaa0715ddebbb39a331224af1b46fdaa
+              GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED: '1'
     runs-on: ${{ matrix.os }}
+    env: ${{ matrix.env }}
     steps:
-      - name: Set up Homebrew self-hosted
-        if: contains(${{ matrix.os }}, 'self-hosted')
-        env:
-          # This environment variable is not documented, but is needed to
-          # prevent failures and destructive actions added in this commit:
-          # https://github.com/Homebrew/actions/commit/616a563beaa0715ddebbb39a331224af1b46fdaa
-          GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED: 1
-        uses: Homebrew/actions/setup-homebrew@master
-        with:
-          debug: true
-
       - name: Set up Homebrew
-        if: contains(${{ matrix.os }}, 'self-hosted') == false
         uses: Homebrew/actions/setup-homebrew@master
         with:
           debug: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,10 +14,22 @@ jobs:
           - [self-hosted, macos, arm64]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Set up Homebrew self-hosted
+        if: contains(${{ matrix.os }}, 'self-hosted')
+        env:
+          # This environment variable is not documented, but is needed to
+          # prevent failures and destructive actions added in this commit:
+          # https://github.com/Homebrew/actions/commit/616a563beaa0715ddebbb39a331224af1b46fdaa
+          GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED: 1
+        uses: Homebrew/actions/setup-homebrew@master
+        with:
+          debug: true
+
       - name: Set up Homebrew
-        # NOTE: A specific commit is used here b/c this action does not
-        #       publish tags and the current `master` appears to be broken.
-        uses: Homebrew/actions/setup-homebrew@449449e64aaa5faac0d24229a2ffba32438e4b63
+        if: contains(${{ matrix.os }}, 'self-hosted') == false
+        uses: Homebrew/actions/setup-homebrew@master
+        with:
+          debug: true
 
       - run: brew test-bot --only-cleanup-before
 
@@ -38,7 +50,9 @@ jobs:
     needs: build-bottles
     steps:
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@449449e64aaa5faac0d24229a2ffba32438e4b63
+        uses: Homebrew/actions/setup-homebrew@master
+        with:
+          debug: true
 
       - name: Checkout the repository
         uses: actions/checkout@v3
@@ -65,7 +79,9 @@ jobs:
     environment: release
     steps:
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@449449e64aaa5faac0d24229a2ffba32438e4b63
+        uses: Homebrew/actions/setup-homebrew@master
+        with:
+          debug: true
 
       - name: Download bottle artifacts
         uses: actions/download-artifact@v3


### PR DESCRIPTION
This change unpins the `Homebrew/actions/setup-homebrew` action. The current pin of the action was set in order to avoid some destructive actions and various errors first introduced in [this commit](https://github.com/Homebrew/actions/commit/616a563beaa0715ddebbb39a331224af1b46fdaa). However, since then the action has been updated and, hopefully, some/all of the errors addressed. The old pin is now causing failures on the `ubuntu-20.04` runner and the thought is that unpinning will get past those errors. The action still makes destructive changes to the `homebrew` install on self-hosted runners. Therefore, the `GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED` environment variable is set specifically for those runners. Given that this action has caused problems regularly, the use of it has been changed to provide debug output always...in an effort to reduce the time it takes to troubleshoot any new errors.