### PR TITLE
fix: Intel 64-bit Linux bottle fails to publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,6 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-20.04
           - macos-latest
         include:
           - os: [self-hosted, macos, arm64]


### PR DESCRIPTION
Repeated attempts to diagnose why the `x86_64_linux` bottle fails to publish were made. Specifically, it fails on the `brew test-bot --only-formulae` step with an error about `No available formula with the name "rust"`. Instead of putting more resources into fixing this issue, it was decided that the user base for this bottle is so small that removing it would not affect usage. Besides, the recommended way of installing the Phylum CLI on linux systems is not with homebrew but with the `curl https://sh.phylum.io sh` command.

BREAKING CHANGE: The Intel 64-bit Linux bottle has been removed.