### PR TITLE
Link to official extensions after install

### DIFF
--- a/Formula/phylum.rb
+++ b/Formula/phylum.rb
@@ -23,6 +23,14 @@ class Phylum < Formula
     fish_completion.install "target/completions/phylum.fish"
   end
 
+  def caveats
+    <<~EOS
+      No official extensions have been installed. For a list of official extensions
+      with installation instructions, see:
+        https://github.com/phylum-dev/cli/tree/main/extensions
+    EOS
+  end
+
   test do
     system "#{bin}/phylum", "version"
   end


### PR DESCRIPTION
Update the `phylum` formula to include a [caveat][] about official extensions.

[caveat]: https://docs.brew.sh/Formula-Cookbook#caveats

With this patch, the `brew install` output looks like this:

```
==> Pouring phylum-5.2.0.arm64_monterey.bottle.tar.gz
==> Caveats
No official extensions have been installed. For a list of official extensions
with installation instructions, see:
  https://github.com/phylum-dev/cli/tree/main/extensions

zsh completions have been installed to:
  /opt/homebrew/share/zsh/site-functions
==> Summary
🍺  /opt/homebrew/Cellar/phylum/5.2.0: 11 files, 89.4MB
```

_Note: Because this patch only updates the formula and does not bump the version (or [revision][]), it will not prompt an upgrade for users that already have the latest version of the Phylum CLI_

[revision]: https://docs.brew.sh/Formula-Cookbook#formulae-revisions