### PR TITLE
Run xtask with cargo run

### DIFF
--- a/Formula/phylum.rb
+++ b/Formula/phylum.rb
@@ -17,7 +17,7 @@ class Phylum < Formula
   def install
     system "cargo", "install", "--no-default-features", *std_cargo_args(path: "cli")
 
-    system "cargo", "xtask", "gencomp"
+    system "cargo", "run", "--package", "xtask", "gencomp"
     bash_completion.install "target/completions/phylum.bash"
     zsh_completion.install "target/completions/_phylum"
     fish_completion.install "target/completions/phylum.fish"


### PR DESCRIPTION
This patch allows the build to work even if the `cargo xtask` alias is removed.