### PR TITLE
Don't use default xtask features

### DIFF
--- a/Formula/phylum.rb
+++ b/Formula/phylum.rb
@@ -18,7 +18,7 @@ class Phylum < Formula
   def install
     system "cargo", "install", "--no-default-features", *std_cargo_args(path: "cli")
 
-    system "cargo", "run", "--package", "xtask", "gencomp"
+    system "cargo", "run", "--package", "xtask", "--no-default-features", "gencomp"
     bash_completion.install "target/completions/phylum.bash"
     zsh_completion.install "target/completions/_phylum"
     fish_completion.install "target/completions/phylum.fish"


### PR DESCRIPTION
This patch prepares for the upcoming update to allow removing the selfmanage feature when generating shell completion files. Once that update is in place (i.e., after the next CLI release), this should produce shell completion files without `phylum uninstall` or other disabled commands.

There will be no updated bottles for this PR, so CI has been intentionally skipped.