### PR TITLE
Deprecate the `phylum` formula

### DIFF
--- a/Formula/phylum.rb
+++ b/Formula/phylum.rb
@@ -13,8 +13,21 @@ class Phylum < Formula
     sha256 cellar: :any_skip_relocation, monterey:      "78e13753bc3d9e931f1f01b9db89c20d14bd3beaec9aa18a6a5e7ecc8d4f9e14"
   end
 
+  deprecate! date: "2024-02-14",
+    because: <<~EOS
+      is available as `phylum-cli` in core tap!
+      To migrate:
+
+        brew uninstall phylum
+        brew untap phylum-dev/cli
+        brew install phylum-cli
+
+    EOS
+
   depends_on "rust" => :build
   depends_on "protobuf" => :build
+
+  conflicts_with "phylum-cli", because: "both install `phylum` binaries"
 
   def install
     system "cargo", "install", "--no-default-features", *std_cargo_args(path: "cli")

--- a/Formula/phylum.rb
+++ b/Formula/phylum.rb
@@ -8,9 +8,9 @@ class Phylum < Formula
 
   bottle do
     root_url "https://github.com/phylum-dev/homebrew-cli/releases/download/phylum-6.1.1"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "f220c004752c81eef5a849503221639f1ddbf24ffca5077b978acb775084d1d2"
-    sha256 cellar: :any_skip_relocation, ventura:       "0e4e9c057c7c3e59555016512c7f448f186be5b26f6603ab5ce0bf4b195e68eb"
-    sha256 cellar: :any_skip_relocation, monterey:      "78e13753bc3d9e931f1f01b9db89c20d14bd3beaec9aa18a6a5e7ecc8d4f9e14"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "a1b913b8c2973306413f6e57f82895bdf35718b1c02902b21cfeaf815b4459e7"
+    sha256 cellar: :any_skip_relocation, ventura:       "b0e7d2c9fb651a9da75dd6c49b319d5cdb118990fbd5587cad954a6acd49ac89"
+    sha256 cellar: :any_skip_relocation, monterey:      "96100b4624694d6bb6a22398e14ff7993299e35210137b644ecafb77f547e6a8"
   end
 
   deprecate! date: "2024-02-14",

--- a/README.md
+++ b/README.md
@@ -1,12 +1,45 @@
 # Phylum CLI
 
-This repository contains [Homebrew] formulae for the [Phylum] [CLI].
+This repository contains **deprecated** [Homebrew] formulae for the [Phylum] [CLI].
+
+> **NOTE:** The `phylum` formula in this custom homebrew tap has been deprecated
+> now that the official Homebrew core tap includes a `phylum-cli` formula that
+> does the same thing. A future release of the Phylum CLI will result in the
+> formula from this custom tap being **disabled** and not possible to install.
 
 [Homebrew]: https://brew.sh/
 [Phylum]: https://phylum.io/
 [CLI]: https://github.com/phylum-dev/cli
 
+## How do I migrate to the supported formula?
+
+It is strongly recommended to migrate to the `phylum-cli` formula found in the
+core Homebrew tap ASAP. If the Phylum CLI is already installed from this custom
+`phylum-dev/cli` tap, follow these steps to migrate:
+
+```sh
+# Uninstall the current formula to prevent `phylum` binary conflicts
+brew uninstall phylum
+
+# Remove the custom tap to prevent accidentally installing the wrong version
+brew untap phylum-dev/cli
+
+# Update and install the new formula from the core tap
+brew update
+brew install phylum-cli
+```
+
+It is even easier if the Phylum CLI was never installed from this custom
+`phylum-dev/cli` tap:
+
+```sh
+brew install phylum-cli
+```
+
 ## How do I install these formulae?
+
+> **NOTE:** These instructions are only included for historical purposes.
+> It is recommended to install the CLI from the core Homebrew tap instead.
 
 `brew install phylum-dev/cli/<formula>`
 


### PR DESCRIPTION
Adding a `deprecate!` statement to the formula for the existing version (v6.1.1) does nothing for users who already have this version installed but it does print a warning and allow install when the version is not already installed.

Adding the `conflicts_with` statement helps to prevent conflicts with the `phylum-cli` formula in the core Homebrew tap and shows this error:

```
Error: Cannot install phylum-dev/cli/phylum because conflicting formulae are installed.
  phylum-cli: because both install `phylum` binaries

Please `brew unlink phylum-cli` before continuing.

Unlinking removes a formula's symlinks from /opt/homebrew. You can
link the formula again after the install finishes. You can `--force` this
install, but the build may fail or cause obscure side effects in the
resulting software.
```

## Testing

The changes were tested with locally, with a clone of this repository.
This is what the deprecation message looks like:

```
❯ brew install phylum
Warning: maxrake/cli/phylum has been deprecated because it is available as `phylum-cli` in core tap!
To migrate:

  brew uninstall phylum
  brew untap phylum-dev/cli
  brew install phylum-cli

!
==> Fetching maxrake/cli/phylum
==> Downloading https://github.com/phylum-dev/homebrew-cli/releases/download/phylum-6.1.1/phylum-6.1.1.arm64_ventura.bottle.tar.gz
Already downloaded: /Users/maxrake/Library/Caches/Homebrew/downloads/be4f71881a6340314c912fe82bbb006936c3add79e1d29e12609e6145de9bcee--phylum-6.1.1.arm64_ventura.bottle.tar.gz
==> Installing phylum from maxrake/cli
==> Pouring phylum-6.1.1.arm64_ventura.bottle.tar.gz
==> Caveats
No official extensions have been installed. For a list of official extensions
with installation instructions, see:
  https://github.com/phylum-dev/cli/tree/main/extensions

zsh completions have been installed to:
  /opt/homebrew/share/zsh/site-functions
==> Summary
🍺  /opt/homebrew/Cellar/phylum/6.1.1: 11 files, 111.0MB
==> Running `brew cleanup phylum`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
```